### PR TITLE
fix: Remove unnecessary warning on tvOS

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -328,10 +328,6 @@ RCT_EXPORT_MODULE()
 {
   RCTAssertThread(RCTGetMethodQueue(), @"Must be executed on storage thread");
 
-#if TARGET_OS_TV
-  RCTLogWarn(@"Persistent storage is not supported on tvOS, your data may be removed at any point.");
-#endif
-
   NSError *error = nil;
   if (!RCTHasCreatedStorageDirectory) {
     [[NSFileManager defaultManager] createDirectoryAtPath:RCTGetStorageDirectory()


### PR DESCRIPTION
Summary:
---------

Since react-native-async-storage on tvOS works without problem, we should remove unnecessary warning

Test Plan:
----------

Run code on tvOS