### PR TITLE
fix: Allow void for ItemGetCallbackType in mock storage

### DIFF
--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -6,7 +6,7 @@
 type KeysType = Array<string>;
 type KeyValueType = Array<Array<*>>;
 type CallbackType = ((?Error) => void) | void;
-type ItemGetCallbackType = (?Error, ?string) => void;
+type ItemGetCallbackType = (?Error, ?string) => void | void;
 type ResultCallbackType = ((?Error, ?KeyValueType) => void) | void;
 
 const asMock = {

--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -6,7 +6,7 @@
 type KeysType = Array<string>;
 type KeyValueType = Array<Array<*>>;
 type CallbackType = ((?Error) => void) | void;
-type ItemGetCallbackType = (?Error, ?string) => void | void;
+type ItemGetCallbackType = ((?Error, ?string) => void) | void;
 type ResultCallbackType = ((?Error, ?KeyValueType) => void) | void;
 
 const asMock = {


### PR DESCRIPTION
To unify the types for all callbacks, also allow `undefined` for the callback of `getItem`.

Summary:
---------
Flow complains because the `getItem` mock doesn't have an optional callback. Unify the callback types to include a `void` for the specific mock as well to mitigate.

Test Plan:
----------

To test, make sure that the `getItem` also allows a callback that is `undefined` without it throwing a Flow error.