### PR TITLE
Add ios build directory to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -61,6 +61,7 @@ ios/*.xcodeproj/xcuserdata
 *.xcuserstate
 project.xcworkspace/
 xcuserdata/
+ios/build/
 
 # Misc
 .DS_Store


### PR DESCRIPTION
Summary:
---------

Add `ios/build` directory to the `.npmignore` file.
Android build directory is already part of the `.npmignore`, but it was not done for iOS build directory, resulting in the published package to contain the whole local iOS build directory :(

Test Plan:
----------

No code change, and no use of any files from the build directory in the code base, so not real testing done apart from running `npm pack` to make sure that the iOS build directory was properly kept outside the npm package.