### PR TITLE
fix: getAllKeys() Jest mock returns array of keys

### DIFF
--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -40,7 +40,7 @@ const asMock = {
   ),
 
   clear: jest.fn<[CallbackType], Promise<*>>(_clear),
-  getAllKeys: jest.fn<[], void>(),
+  getAllKeys: jest.fn<[], Promise<string[]>>(_getAllKeys),
   flushGetRequests: jest.fn<[], void>(),
 
   multiGet: jest.fn<[KeysType, ResultCallbackType], Promise<*>>(_multiGet),
@@ -87,6 +87,10 @@ async function _clear(callback: CallbackType) {
   callback && callback(null);
 
   return null;
+}
+
+async function _getAllKeys() {
+  return Object.keys(asMock.__INTERNAL_MOCK_STORAGE__);
 }
 
 async function _multiMerge(


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->

The `AsyncStorage.getAllKeys()` method in the Jest mock wasn't mocked to return the mock storage keys. This changes the mock such that `getAllKeys` will by default return the mock storage keys. Without this change, lib users will have to mock `getAllKeys`.


Test Plan:
----------

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->

I don't have a perfect test plan, but you can test by writing a Jest test that will have code that executes `AsyncStorage.getAllKeys()`. The default mock will not return the mock storage keys.