### PR TITLE
Add tvOS to podspec supported platforms

### DIFF
--- a/RNCAsyncStorage.podspec
+++ b/RNCAsyncStorage.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platforms    = { :ios => "9.0", :tvos => "9.2" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-async-storage.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
Summary:
---------

After upgrading my tvOS project to RN 0.60+, I found the new pod auto-linking feature wasn't working for async-storage on tvOS due to support not being specified for tvOS. Adding this to the podspec allows `pod install` to work correctly for tvOS.



Test Plan:
----------

Try and use async-storage in a tvOS project on RN 0.60+. Note that `pod install` will throw an error (tvOS not supported). Update the podspec as per this PR and try again and it will work.
