### PR TITLE
Update build.gradle setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,6 @@
 #
 .DS_Store
 
-# node.js
-#
-node_modules/
-npm-debug.log
-yarn-error.log
-  
-
 # Xcode
 #
 build/
@@ -29,7 +22,6 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      
 
 # Android/IntelliJ
 #
@@ -38,6 +30,15 @@ build/
 .gradle
 local.properties
 *.iml
+android/gradle/
+android/gradlew
+android/gradlew.bat
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
 
 # BUCK
 buck-out/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,21 +1,20 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
-    repositories {
-        google()
-        jcenter()
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.0'
+        }
     }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-    }
-}
-
-def getExtOrDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['RNAsyncStorage_' + name]
-}
-
-def getExtOrIntegerDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['RNAsyncStorage_' + name]).toInteger()
 }
 
 // AsyncStorage has default size of 6MB.
@@ -37,22 +36,30 @@ def useDedicatedExecutor = rootProject.hasProperty('AsyncStorage_dedicatedExecut
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-    buildToolsVersion getExtOrDefault('buildToolsVersion')
-
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
-        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
-        targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-
+        minSdkVersion safeExtGet('minSdkVersion', 19)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField("boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}")
+    }
+    lintOptions {
+        abortOnError false
     }
 }
 
 repositories {
-    mavenCentral()
+    mavenLocal()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+    }
+    google()
+    jcenter()
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,0 @@
-RNAsyncStorage_compileSdkVersion=28
-RNAsyncStorage_buildToolsVersion=28.0.3
-RNAsyncStorage_targetSdkVersion=28
-RNAsyncStorage_minSdkVersion=19


### PR DESCRIPTION
# Summary

A slightly different approach to #207 

This wraps the Android Gradle plugin dependency in the `buildscripts` section of `android/build.gradle` in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is _only_ required when opening the project _stand-alone_, not when it is _included as a dependency_. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project **without** affecting the app project (avoiding unnecessary downloads/conflicts/etc).

# Test Plan

## What's required for testing (prerequisites)?

Android Studio and/or Gradle installed locally.

## What are the steps to reproduce (after prerequisites)?

Open `android` in Android Studio:

```sh
studio android/
```

Or:

Generate a Gradle wrapper on the fly, and build on command line:

```sh
cd android/
gradle wrapper --gradle-version 5.4.1 --distribution-type all
./gradlew build
```

Successfully verified and tested on:
- Android Device (Xiaomi Mi A2)
- Android Emulator (Pixel 3a)
- iOS Device (iPhone 8)
- iOS Simulator (iPhone X)

<sub><sup>Once approved, please use a *normal* GitHub merge (i.e. **NO rebase/squash** merge) to integrate the commit(s) from the PR head branch. The changes are broken up into meaningful, [atomic commits](https://www.freshconsulting.com/atomic-commits/), and my branch should already be up-to-date with the latest base branch. If it isn't, or if you want me to change anything, please let me know, and I will update the branch as soon as possible. Thank you!</sup></sub>