### PR TITLE
feat: add warning to set functions when value is not a string (#230)

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {NativeModules, Platform} = require('react-native');
+const {NativeModules} = require('react-native');
 
 const RCTAsyncStorage =
   NativeModules.RNC_AsyncSQLiteDBStorage ||
@@ -51,6 +51,14 @@ type MultiRequest = {|
   resolve: ?(result?: Promise<?$ReadOnlyArray<ReadOnlyArrayString>>) => void,
   reject: ?(error?: any) => void,
 |};
+
+function checkValueTypeNotString(value: any, usedKey: string) {
+  if (typeof value !== 'string') {
+    console.warn(
+      `[AsyncStorage] The value for key "${usedKey}" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.`,
+    );
+  }
+}
 
 /**
  * `AsyncStorage` is a simple, unencrypted, asynchronous, persistent, key-value
@@ -100,11 +108,7 @@ const AsyncStorage = {
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key, value]], function(errors) {
-        if (Platform.OS === 'ios' && typeof value !== 'string') {
-          console.warn(
-            '[AsyncStorage] The type of the value must be a string. Consider casting to string or using the stringify() method.',
-          );
-        }
+        checkValueTypeNotString(value, key);
         const errs = convertErrors(errors);
         callback && callback(errs && errs[0]);
         if (errs) {
@@ -306,6 +310,10 @@ const AsyncStorage = {
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      keyValuePairs.forEach(([key, value]) => {
+        checkValueTypeNotString(value, key);
+      });
+
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
         const error = convertErrors(errors);
         callback && callback(error);

--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {NativeModules} = require('react-native');
+const {NativeModules, Platform} = require('react-native');
 
 const RCTAsyncStorage =
   NativeModules.RNC_AsyncSQLiteDBStorage ||
@@ -100,6 +100,11 @@ const AsyncStorage = {
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key, value]], function(errors) {
+        if (Platform.OS === 'ios' && typeof value !== 'string') {
+          console.warn(
+            '[AsyncStorage] The type of the value must be a string. Consider casting to string or using the stringify() method.',
+          );
+        }
         const errs = convertErrors(errors);
         callback && callback(errs && errs[0]);
         if (errs) {


### PR DESCRIPTION
Summary:
---------
Added warning on iOS when the value in the second argument of the `setItem` method is not a string.

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->


Test Plan:
----------
Change the second argument of the `setItem` method in `example/src/examples/GetSetClear.js`, line 41 to non-string type and then try to increase the stored value. The warning will appear.

Example:
```
await AsyncStorage.setItem(STORAGE_KEY, newNumber);
await AsyncStorage.setItem(STORAGE_KEY, {newNumber});
await AsyncStorage.setItem(STORAGE_KEY, [newNumber]);
await AsyncStorage.setItem(STORAGE_KEY, null);
```

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->