### PR TITLE
Prefer PlatformLocalStorage Over Other Native Modules

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -14,9 +14,9 @@
 const {NativeModules} = require('react-native');
 
 const RCTAsyncStorage =
+  NativeModules.PlatformLocalStorage || // Support for external modules, like react-native-windows
   NativeModules.RNC_AsyncSQLiteDBStorage ||
-  NativeModules.RNCAsyncStorage ||
-  NativeModules.PlatformLocalStorage; // Support for external modules, like react-native-windows
+  NativeModules.RNCAsyncStorage;
 
 if (!RCTAsyncStorage) {
   throw new Error(`[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null.


### PR DESCRIPTION
We currently try to load builtin native modules before trying to
fallback to platform provided native modules. Reversing this order
allows the platform to provide the AsyncStorage implementtion even if
on a platform that async-storage already supports. This ability can
be useful in hosted scenarios where we may want more control over how
data for an individual React Native instance is stored.

This should be entirely unneeded for AsyncStorageV2 since we have IStorageBackend.