### PR TITLE
fix(android): throw error when value is `null`

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -52,11 +52,25 @@ type MultiRequest = {|
   reject: ?(error?: any) => void,
 |};
 
-function checkValueTypeNotString(value: any, usedKey: string) {
-  if (typeof value !== 'string') {
+function checkValidInput(usedKey: string, value: any) {
+  const isValuePassed = arguments.length > 1;
+
+  if (typeof usedKey !== 'string') {
     console.warn(
-      `[AsyncStorage] The value for key "${usedKey}" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.`,
+      `[AsyncStorage] Using ${typeof usedKey} type for key is not supported. This can lead to unexpected behavior/errors. Use string instead.\nKey passed: ${usedKey}\n`,
     );
+  }
+
+  if (isValuePassed && typeof value !== 'string') {
+    if (value == null) {
+      throw new Error(
+        `[AsyncStorage] Passing null/undefined as value is not supported. If you want to remove value, Use .remove method instead.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
+      );
+    } else {
+      console.warn(
+        `[AsyncStorage] The value for key "${usedKey}" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
+      );
+    }
   }
 }
 
@@ -82,6 +96,7 @@ const AsyncStorage = {
     callback?: ?(error: ?Error, result: string | null) => void,
   ): Promise<string | null> {
     return new Promise((resolve, reject) => {
+      checkValidInput(key);
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
         const value = result && result[0] && result[0][1] ? result[0][1] : null;
@@ -107,8 +122,8 @@ const AsyncStorage = {
     callback?: ?(error: ?Error) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      checkValidInput(key, value);
       RCTAsyncStorage.multiSet([[key, value]], function(errors) {
-        checkValueTypeNotString(value, key);
         const errs = convertErrors(errors);
         callback && callback(errs && errs[0]);
         if (errs) {
@@ -130,6 +145,7 @@ const AsyncStorage = {
     callback?: ?(error: ?Error) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      checkValidInput(key);
       RCTAsyncStorage.multiRemove([key], function(errors) {
         const errs = convertErrors(errors);
         callback && callback(errs && errs[0]);
@@ -156,6 +172,7 @@ const AsyncStorage = {
     callback?: ?(error: ?Error) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      checkValidInput(key, value);
       RCTAsyncStorage.multiMerge([[key, value]], function(errors) {
         const errs = convertErrors(errors);
         callback && callback(errs && errs[0]);
@@ -311,7 +328,7 @@ const AsyncStorage = {
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       keyValuePairs.forEach(([key, value]) => {
-        checkValueTypeNotString(value, key);
+        checkValidInput(key, value);
       });
 
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
@@ -336,6 +353,8 @@ const AsyncStorage = {
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      keys.forEach(checkValidInput);
+
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         const error = convertErrors(errors);
         callback && callback(error);


### PR DESCRIPTION
Summary:
---------
 
Android did not show errors when `null`/`undefined` values were passed. This PR fixes that.

Closes #253 


Test Plan:
----------

1. Try setting a  `null`/`undefined` value to AsyncStorage.
2. Note that errors where thrown.