### PR TITLE
Update AsyncStorage.js

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -353,7 +353,7 @@ const AsyncStorage = {
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
-      keys.forEach(key => checkValidInput(key, 'value'));
+      keys.forEach(key => checkValidInput(key));
 
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         const error = convertErrors(errors);

--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -353,7 +353,7 @@ const AsyncStorage = {
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
-      keys.forEach(checkValidInput);
+      keys.forEach(key => checkValidInput(key, 'value'));
 
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         const error = convertErrors(errors);


### PR DESCRIPTION
Summary:
---------
```js

AsyncStorage.multiRemove(['a']);

/*
[AsyncStorage] The value for key "a" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.
Passed value: 0
Passed key: a
*/
```

Fixed https://github.com/react-native-community/async-storage/issues/267


Test Plan:
----------
```js
AsyncStorage.multiRemove(['a']);
```

