### PR TITLE
Don't reset the storage when the manifest file cannot be read because of iOS data protection

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -348,20 +348,20 @@ RCT_EXPORT_MODULE()
     NSDictionary *errorOut = nil;
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
     if (!serialized) {
-    	if (errorOut) {
-     		// We cannot simply create a new manifest in case the file does exist but we have no access to it.
-				// This can happen when data protection is enabled for the app and we are trying to read the manifect
-				// while the device is locked. (The app can be started by the system even if the device is locked due to
-				// e.g. a geofence event.)
-      	RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
-      	return errorOut;
+      if (errorOut) {
+        // We cannot simply create a new manifest in case the file does exist but we have no access to it.
+        // This can happen when data protection is enabled for the app and we are trying to read the manifect
+        // while the device is locked. (The app can be started by the system even if the device is locked due to
+        // e.g. a geofence event.)
+        RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
+        return errorOut;
       } else {
-      	// We can get nil without errors only when the file does not exist.
+        // We can get nil without errors only when the file does not exist.
         RCTLogTrace(@"Manifest does not exist - creating a new one.\n\n%@", errorOut);
         _manifest = [NSMutableDictionary new];
       }
     } else {
-    	_manifest = RCTJSONParseMutable(serialized, &error);
+      _manifest = RCTJSONParseMutable(serialized, &error);
       if (!_manifest) {
         RCTLogError(@"Failed to parse manifest - creating a new one.\n\n%@", error);
         _manifest = [NSMutableDictionary new];

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -343,16 +343,33 @@ RCT_EXPORT_MODULE()
     }
     RCTHasCreatedStorageDirectory = YES;
   }
+
   if (!_haveSetup) {
-    NSDictionary *errorOut;
+    NSDictionary *errorOut = nil;
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
-    _manifest = serialized ? RCTJSONParseMutable(serialized, &error) : [NSMutableDictionary new];
-    if (error) {
-      RCTLogWarn(@"Failed to parse manifest - creating new one.\n\n%@", error);
-      _manifest = [NSMutableDictionary new];
+    if (!serialized) {
+    	if (errorOut) {
+     		// We cannot simply create a new manifest in case the file does exist but we have no access to it.
+				// This can happen when data protection is enabled for the app and we are trying to read the manifect
+				// while the device is locked. (The app can be started by the system even if the device is locked due to
+				// e.g. a geofence event.)
+      	RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
+      	return errorOut;
+      } else {
+      	// We can get nil without errors only when the file does not exist.
+        RCTLogTrace(@"Manifest does not exist - creating a new one.\n\n%@", errorOut);
+        _manifest = [NSMutableDictionary new];
+      }
+    } else {
+    	_manifest = RCTJSONParseMutable(serialized, &error);
+      if (!_manifest) {
+        RCTLogError(@"Failed to parse manifest - creating a new one.\n\n%@", error);
+        _manifest = [NSMutableDictionary new];
+      }
     }
     _haveSetup = YES;
   }
+
   return nil;
 }
 

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -350,7 +350,7 @@ RCT_EXPORT_MODULE()
     if (!serialized) {
       if (errorOut) {
         // We cannot simply create a new manifest in case the file does exist but we have no access to it.
-        // This can happen when data protection is enabled for the app and we are trying to read the manifect
+        // This can happen when data protection is enabled for the app and we are trying to read the manifest
         // while the device is locked. (The app can be started by the system even if the device is locked due to
         // e.g. a geofence event.)
         RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);


### PR DESCRIPTION
Summary:
---------

This is to distinguish "manifest file does not exist or is corrupted" and "have no access to the manifest file yet" cases.

Starting with an empty dictionary is a reasonable fallback in case the manifest does not exist or cannot be parsed because of being corrupted or incompatible. However doing so might lead to unnecessary data loss when the app simply has no access to its documents yet due to iOS data protection (if enabled and when the app launches while the device is locked due to e.g. geofencing, silent notification, external accessory, etc).

Test Plan:
----------

Enable data protection in your RN iOS app, then trigger a geofencing event or a silent push notification to launch the app while the phone is locked and files are not readable. If the app tries to access async storage in this case, then it'll end up erasing it without this fix. 