### PR TITLE
[FIX] Move the storage location on iOS to Application Support

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -111,17 +111,9 @@ static NSString *RCTGetStorageDirectory()
   return storageDirectory;
 }
 
-// DO NOT USE
-// This is used internally to migrate data from the old file location to the new one.
-// Please use `RCTCreateManifestFilePath` instead
-static NSString *RCTCreateManifestFilePath_deprecated(NSString *storageDirectory)
-{
-  return [RCTCreateStorageDirectoryPath_deprecated(storageDirectory) stringByAppendingPathComponent:RCTManifestFileName];
-}
-
 static NSString *RCTCreateManifestFilePath(NSString *storageDirectory)
 {
-  return [RCTCreateStorageDirectoryPath(storageDirectory) stringByAppendingPathComponent:RCTManifestFileName];
+  return [storageDirectory stringByAppendingPathComponent:RCTManifestFileName];
 }
 
 static NSString *RCTGetManifestFilePath()
@@ -216,18 +208,18 @@ static void RCTStorageDirectoryMigrationLogError(NSString *reason, NSError *erro
 static void RCTStorageDirectoryCleanupOld(NSString *oldDirectoryPath)
 {
   NSError *error;
-  if (![[NSFileManager defaultManager] removeItemAtPath:RCTCreateStorageDirectoryPath_deprecated(oldDirectoryPath) error:&error]) {
+  if (![[NSFileManager defaultManager] removeItemAtPath:oldDirectoryPath error:&error]) {
     RCTStorageDirectoryMigrationLogError(@"Failed to remove old storage directory during migration", error);
   }
 }
 
-static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath)
+static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *newDirectoryPath, BOOL shouldCleanupOldDirectory)
 {
   NSError *error;
   // Migrate data by copying old storage directory to new storage directory location
-  if (![[NSFileManager defaultManager] copyItemAtPath:RCTCreateStorageDirectoryPath_deprecated(oldDirectoryPath) toPath:RCTGetStorageDirectory() error:&error]) {
+  if (![[NSFileManager defaultManager] copyItemAtPath:oldDirectoryPath toPath:newDirectoryPath error:&error]) {
     RCTStorageDirectoryMigrationLogError(@"Failed to copy old storage directory to new storage directory location during migration", error);
-  } else {
+  } else if (shouldCleanupOldDirectory) {
     // If copying succeeds, remove old storage directory
     RCTStorageDirectoryCleanupOld(oldDirectoryPath);
   }
@@ -239,30 +231,32 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath)
  *  1) Data is migrated from the Documents "RNCAsyncLocalStorage_V1" directory to the "Application Support" directory.
  *  2) Data is migrated from the Documents "RCTAsyncLocalStorage_V1"  directory to the "Application Support" directory.
  */
-static void RCTStorageDirectoryMigrationCheck(NSString *oldStorageDirectory)
+static void RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory, NSString *toStorageDirectory, BOOL shouldCleanupOldDirectory)
 {
   NSError *error;
   BOOL isDir;
   NSFileManager *fileManager = [NSFileManager defaultManager];
   // If the old directory exists, it means we may need to migrate old data to the new directory
-  if ([fileManager fileExistsAtPath:RCTCreateStorageDirectoryPath_deprecated(oldStorageDirectory) isDirectory:&isDir] && isDir) {
+  if ([fileManager fileExistsAtPath:fromStorageDirectory isDirectory:&isDir] && isDir) {
     // Check if the new storage directory location already exists
-    if ([fileManager fileExistsAtPath:RCTGetStorageDirectory()]) {
-      // If new storage location exists, check if the new storage has been modified sooner
-      if ([RCTManifestModificationDate(RCTGetManifestFilePath()) compare:RCTManifestModificationDate(RCTCreateManifestFilePath_deprecated(oldStorageDirectory))] == 1) {
+    if ([fileManager fileExistsAtPath:toStorageDirectory]) {
+      // If new storage location exists, check if the new storage has been modified sooner in which case we may want to cleanup the old location
+      if ([RCTManifestModificationDate(RCTCreateManifestFilePath(toStorageDirectory)) compare:RCTManifestModificationDate(RCTCreateManifestFilePath(fromStorageDirectory))] == 1) {
         // If new location has been modified more recently, simply clean out old data
-        RCTStorageDirectoryCleanupOld(oldStorageDirectory);
+        if (shouldCleanupOldDirectory) {
+          RCTStorageDirectoryCleanupOld(fromStorageDirectory);
+        }
       } else {
         // If old location has been modified more recently, remove new storage and migrate
-        if (![fileManager removeItemAtPath:RCTGetStorageDirectory() error:&error]) {
+        if (![fileManager removeItemAtPath:toStorageDirectory error:&error]) {
           RCTStorageDirectoryMigrationLogError(@"Failed to remove new storage directory during migration", error);
         } else {
-          RCTStorageDirectoryMigrate(oldStorageDirectory);
+          RCTStorageDirectoryMigrate(fromStorageDirectory, toStorageDirectory, shouldCleanupOldDirectory);
         }
       }
     } else {
       // If new storage location doesn't exist, migrate data
-      RCTStorageDirectoryMigrate(oldStorageDirectory);
+      RCTStorageDirectoryMigrate(fromStorageDirectory, toStorageDirectory, shouldCleanupOldDirectory);
     }
   }
 }
@@ -289,9 +283,11 @@ static void RCTStorageDirectoryMigrationCheck(NSString *oldStorageDirectory)
     return nil;
   }
 
-  // Both directories from our deprecated path (Documents) must be migrated to our new path (Application Support/[bundleID])
-  RCTStorageDirectoryMigrationCheck(RCTOldStorageDirectory);
-  RCTStorageDirectoryMigrationCheck(RCTStorageDirectory);
+  // First migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" to "Documents/.../RCTAsyncLocalStorage_V1"
+  RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTOldStorageDirectory), RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), YES);
+  
+  // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application Support/[bundleID]/RCTAsyncLocalStorage_V1"
+  RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), RCTCreateStorageDirectoryPath(RCTStorageDirectory), NO);
 
   return self;
 }
@@ -368,7 +364,7 @@ RCT_EXPORT_MODULE()
   }
   if (!_haveSetup) {
     NSDictionary *errorOut;
-    NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
+    NSString *serialized = RCTReadFile(RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()), RCTManifestFileName, &errorOut);
     _manifest = serialized ? RCTJSONParseMutable(serialized, &error) : [NSMutableDictionary new];
     if (error) {
       RCTLogWarn(@"Failed to parse manifest - creating new one.\n\n%@", error);
@@ -383,7 +379,7 @@ RCT_EXPORT_MODULE()
 {
   NSError *error;
   NSString *serialized = RCTJSONStringify(_manifest, &error);
-  [serialized writeToFile:RCTGetManifestFilePath() atomically:YES encoding:NSUTF8StringEncoding error:&error];
+  [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
   NSDictionary *errorOut;
   if (error) {
     errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -181,7 +181,7 @@ static NSCache *RCTGetCache()
   dispatch_once(&onceToken, ^{
     cache = [NSCache new];
     cache.totalCostLimit = 2 * 1024 * 1024; // 2MB
-    
+
     // Clear cache in the event of a memory warning
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
       [cache removeAllObjects];
@@ -290,15 +290,9 @@ static void RCTStorageDirectoryMigrationCheck(NSString *oldStorageDirectory)
   }
 
   // Both directories from our deprecated path (Documents) must be migrated to our new path (Application Support/[bundleID])
-  static dispatch_once_t onceTokenOldStorage;
-  dispatch_once(&onceTokenOldStorage, ^{
-    RCTStorageDirectoryMigrationCheck(RCTOldStorageDirectory);
-  });
-  static dispatch_once_t onceTokenStorage;
-  dispatch_once(&onceTokenStorage, ^{
-    RCTStorageDirectoryMigrationCheck(RCTStorageDirectory);
-  });
-  
+  RCTStorageDirectoryMigrationCheck(RCTOldStorageDirectory);
+  RCTStorageDirectoryMigrationCheck(RCTStorageDirectory);
+
   return self;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/async-storage",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "types": "./types/index.d.ts",
   "main": "./lib/index.js",


### PR DESCRIPTION
Summary:
---------

Right now on iOS, the data is stored in the Documents directory (NSDocumentDirectory) on iOS and the caches directory (NSCachesDirectory) on tvOS.

These are not the best locations for the following reasons:
* NSDocumentDirectory- this folder is visible on iOS in scenarios where you can view the Files structure. For instance, in Word/PPT/Excel, a user can tap through to this and see a folder titled "RCTAsyncLocalStorage_V1".
* NSCachesDirectory- Apple documents this as a location that can get purged in low memory scenarios "the system may delete the Caches directory on rare occasions when the system is very low on disk space."

This fix moves the location to the Application Support directory (NSApplicationSupportDirectory). This directory is documented by Apple as "[containing] all app-specific data and support files" and it can safely contain user data. There is not risk of this purging in low memory situations and this isn't visible to iOS users.

This is not a breaking change as we are able to maintain fidelity with the one-time data migration code to our new location.

The general fix is this:
* Maintain our existing deprecation/removal of the old Documents/.../RNCAsyncLocalStorage_V1/manifest.json
* Maintain our existing migration from Documents/.../RNCCreateStorageDirectoryPath to Documents/.../RCTAsyncLocalStorage_V1/manifest.json
* Add an additional migration from Documents/.../RCTAsyncLocalStorage_V1/manifest.json to Application Support/[bundleID]/RCTAsyncLocalStorage_V1/manifest.json, but do not delete the Document version
* In the rewrite of RCTCreateStorageDirectoryPath, use NSApplicationSupportDirectory instead of caches or documents
* Refactor our migration methods to take in a from and a to directory path parameter so we can run the migration twice- once with the old caches/documents location paired with RCTOldStorageDirectory and again with the old caches/documents location paired with RCTStorageDirectory. We also added a shouldCleanupOldDirectory parameter so we can optionally delete the "from" path when we're migrating from Documents/RNC* but retain the "from" path when migrating from Documents/RCT*
* Cache some duplicate method calls in a couple places to save on performance

Please see https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html#//apple_ref/doc/uid/TP40010672-CH10-SW1 and https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1 for more documentation on this.

Test Plan:
---------- 
* Ran the example test app on iOS and incremented the counter. Verified this saves by hitting the Restart button and the content persisted.
* Verified that the migration is correct on iOS by stashing this fix, incrementing the counter, popping back this change, and in the debugger I stepped through it copying the data over to the Application Support/[bundleID]/ location. I also verified that it correctly cleared out the old data. Finally, I checked that in the aforementioned migration scenario, there was no data loss in the test app.
* Tested updating the manifest when there was no existing manifest in Documents/RCT*
* Tested updating the manifest when there was no existing manifest in ApplicationSupport/RCT*
* Tested updating the manifest when there was no existing manifest in Documents/RNC*
* Tested updating the manifest when there was an existing manifest in Documents/RCT*
* Tested updating the manifest when there was an existing manifest in ApplicationSupport/RCT*