### PR TITLE
Adds missing colon in the documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -112,7 +112,7 @@ const USER_1 = {
   name: 'Tom',
   age: 20,
   traits: {
-    hair: 'black'
+    hair: 'black',
     eyes: 'blue'
   }
 }


### PR DESCRIPTION
Summary:
---------

Just added a missing colon in the documentation

Test Plan:
----------

Check if docs/API.md:115 have a colon in the end of the line, after the `'black'` string.