### PR TITLE
Create [bundle ID] folder during migration if none exists

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -213,11 +213,29 @@ static void RCTStorageDirectoryCleanupOld(NSString *oldDirectoryPath)
   }
 }
 
+static void _createStorageDirectory(NSString *storageDirectory, NSError **error)
+{
+  [[NSFileManager defaultManager] createDirectoryAtPath:storageDirectory
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:error];
+}
+
 static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *newDirectoryPath, BOOL shouldCleanupOldDirectory)
 {
   NSError *error;
   // Migrate data by copying old storage directory to new storage directory location
   if (![[NSFileManager defaultManager] copyItemAtPath:oldDirectoryPath toPath:newDirectoryPath error:&error]) {
+    // the new storage directory "Application Support/[bundleID]/RCTAsyncLocalStorage_V1" seems unable to migrate
+    // because folder "Application Support/[bundleID]" doesn't exist.. create this folder so and attempt to migrate again
+    if (error != nil && error.code == 4 && [newDirectoryPath hasSuffix:RCTStorageDirectory]) {
+        NSError *error = nil;
+        _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
+        if (error == nil) {
+          RCTStorageDirectoryMigrate(oldDirectoryPath, newDirectoryPath, shouldCleanupOldDirectory);
+          return;
+        }
+      }
     RCTStorageDirectoryMigrationLogError(@"Failed to copy old storage directory to new storage directory location during migration", error);
   } else if (shouldCleanupOldDirectory) {
     // If copying succeeds, remove old storage directory
@@ -354,10 +372,7 @@ RCT_EXPORT_MODULE()
 
   NSError *error = nil;
   if (!RCTHasCreatedStorageDirectory) {
-    [[NSFileManager defaultManager] createDirectoryAtPath:RCTGetStorageDirectory()
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:&error];
+    _createStorageDirectory(RCTGetStorageDirectory(), &error);
     if (error) {
       return RCTMakeError(@"Failed to create storage directory.", error, nil);
     }

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -228,7 +228,7 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *new
   if (![[NSFileManager defaultManager] copyItemAtPath:oldDirectoryPath toPath:newDirectoryPath error:&error]) {
     // the new storage directory "Application Support/[bundleID]/RCTAsyncLocalStorage_V1" seems unable to migrate
     // because folder "Application Support/[bundleID]" doesn't exist.. create this folder and attempt folder copying again
-    if (error != nil && error.code == 4 && [newDirectoryPath hasSuffix:RCTStorageDirectory]) {
+    if (error != nil && error.code == 4 && [newDirectoryPath isEqualToString:RCTGetStorageDirectory()]) {
         NSError *error = nil;
         _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
         if (error == nil) {

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -229,14 +229,16 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *new
     // the new storage directory "Application Support/[bundleID]/RCTAsyncLocalStorage_V1" seems unable to migrate
     // because folder "Application Support/[bundleID]" doesn't exist.. create this folder and attempt folder copying again
     if (error != nil && error.code == 4 && [newDirectoryPath isEqualToString:RCTGetStorageDirectory()]) {
-        NSError *error = nil;
-        _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
-        if (error == nil) {
-          RCTStorageDirectoryMigrate(oldDirectoryPath, newDirectoryPath, shouldCleanupOldDirectory);
-          return;
-        }
+      NSError *error = nil;
+      _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
+      if (error == nil) {
+        RCTStorageDirectoryMigrate(oldDirectoryPath, newDirectoryPath, shouldCleanupOldDirectory);
+      } else {
+        RCTStorageDirectoryMigrationLogError(@"Failed to create storage directory during migration.", error);
       }
-    RCTStorageDirectoryMigrationLogError(@"Failed to copy old storage directory to new storage directory location during migration", error);
+    } else {
+      RCTStorageDirectoryMigrationLogError(@"Failed to copy old storage directory to new storage directory location during migration", error);
+    }
   } else if (shouldCleanupOldDirectory) {
     // If copying succeeds, remove old storage directory
     RCTStorageDirectoryCleanupOld(oldDirectoryPath);

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -227,7 +227,7 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *new
   // Migrate data by copying old storage directory to new storage directory location
   if (![[NSFileManager defaultManager] copyItemAtPath:oldDirectoryPath toPath:newDirectoryPath error:&error]) {
     // the new storage directory "Application Support/[bundleID]/RCTAsyncLocalStorage_V1" seems unable to migrate
-    // because folder "Application Support/[bundleID]" doesn't exist.. create this folder so and attempt to migrate again
+    // because folder "Application Support/[bundleID]" doesn't exist.. create this folder and attempt folder copying again
     if (error != nil && error.code == 4 && [newDirectoryPath hasSuffix:RCTStorageDirectory]) {
         NSError *error = nil;
         _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->

fixes issue described in https://github.com/react-native-community/async-storage/issues/301

Test Plan:
----------

you can use my sample repo here: https://github.com/frankenthumbs/AsyncStorageUpgradePOC and use the repro steps but the gist is, on iOS:
1. save something in async storage on version 1.2.1
2. upgrade to latest
3. noticed data doesn't get wiped

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->