### PR TITLE
update react native doc links with new docs url

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -79,7 +79,7 @@ function checkValidInput(usedKey: string, value: any) {
  * storage system that is global to the app.  It should be used instead of
  * LocalStorage.
  *
- * See http://facebook.github.io/react-native/docs/asyncstorage.html
+ * See http://reactnative.dev/docs/asyncstorage.html
  */
 const AsyncStorage = {
   _getRequests: ([]: Array<MultiRequest>),
@@ -89,7 +89,7 @@ const AsyncStorage = {
   /**
    * Fetches an item for a `key` and invokes a callback upon completion.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#getitem
+   * See http://reactnative.dev/docs/asyncstorage.html#getitem
    */
   getItem: function(
     key: string,
@@ -114,7 +114,7 @@ const AsyncStorage = {
   /**
    * Sets the value for a `key` and invokes a callback upon completion.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#setitem
+   * See http://reactnative.dev/docs/asyncstorage.html#setitem
    */
   setItem: function(
     key: string,
@@ -138,7 +138,7 @@ const AsyncStorage = {
   /**
    * Removes an item for a `key` and invokes a callback upon completion.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#removeitem
+   * See http://reactnative.dev/docs/asyncstorage.html#removeitem
    */
   removeItem: function(
     key: string,
@@ -164,7 +164,7 @@ const AsyncStorage = {
    *
    * **NOTE:** This is not supported by all native implementations.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#mergeitem
+   * See http://reactnative.dev/docs/asyncstorage.html#mergeitem
    */
   mergeItem: function(
     key: string,
@@ -190,7 +190,7 @@ const AsyncStorage = {
    * don't want to call this; use `removeItem` or `multiRemove` to clear only
    * your app's keys.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#clear
+   * See http://reactnative.dev/docs/asyncstorage.html#clear
    */
   clear: function(callback?: ?(error: ?Error) => void): Promise<null> {
     return new Promise((resolve, reject) => {
@@ -209,7 +209,7 @@ const AsyncStorage = {
   /**
    * Gets *all* keys known to your app; for all callers, libraries, etc.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#getallkeys
+   * See http://reactnative.dev/docs/asyncstorage.html#getallkeys
    */
   getAllKeys: function(
     callback?: ?(error: ?Error, keys: ?ReadOnlyArrayString) => void,
@@ -240,7 +240,7 @@ const AsyncStorage = {
   /**
    * Flushes any pending requests using a single batch call to get the data.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#flushgetrequests
+   * See http://reactnative.dev/docs/asyncstorage.html#flushgetrequests
    * */
   flushGetRequests: function(): void {
     const getRequests = this._getRequests;
@@ -278,7 +278,7 @@ const AsyncStorage = {
    * inputs. Your callback will be invoked with an array of corresponding
    * key-value pairs found.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#multiget
+   * See http://reactnative.dev/docs/asyncstorage.html#multiget
    */
   multiGet: function(
     keys: Array<string>,
@@ -320,7 +320,7 @@ const AsyncStorage = {
    * Use this as a batch operation for storing multiple key-value pairs. When
    * the operation completes you'll get a single callback with any errors.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#multiset
+   * See http://reactnative.dev/docs/asyncstorage.html#multiset
    */
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
@@ -346,7 +346,7 @@ const AsyncStorage = {
   /**
    * Call this to batch the deletion of all keys in the `keys` array.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#multiremove
+   * See http://reactnative.dev/docs/asyncstorage.html#multiremove
    */
   multiRemove: function(
     keys: Array<string>,
@@ -373,7 +373,7 @@ const AsyncStorage = {
    *
    * **NOTE**: This is not supported by all native implementations.
    *
-   * See http://facebook.github.io/react-native/docs/asyncstorage.html#multimerge
+   * See http://reactnative.dev/docs/asyncstorage.html#multimerge
    */
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,


### PR DESCRIPTION
Summary:
---------

Facebook changed the URL of the React Native docs from `facebook.github.io/react-native` to `reactnative.dev`.  This PR updated all the links pointing to the old docs site with the updated link. 

Test Plan:
----------

No code changed. Only comments were updated.