### PR TITLE
fix(v2 mobile): dropStorage throw error

### DIFF
--- a/packages/storage-legacy/src/index.ts
+++ b/packages/storage-legacy/src/index.ts
@@ -217,7 +217,7 @@ export default class LegacyAsyncStorage<
       this._asyncStorageNativeModule.clear(function(error: Array<Error>) {
         const err = convertErrors(Array.isArray(error) ? error : [error]);
 
-        if (err) {
+        if (err && err.length) {
           reject(err);
         } else {
           resolve();


### PR DESCRIPTION
Summary:
---------
clearStorage will throw error. I have commented on this thread.
https://github.com/react-native-community/async-storage/issues/113#issuecomment-603645796

![Simulator Screen Shot - iPhone X - 2020-03-25 at 13 13 11](https://user-images.githubusercontent.com/47012/77507739-f48fa280-6ea3-11ea-8f6a-5dff8c023d2e.png)

Test Plan:
----------

```
import storage from './storage.ts';

await storage.clearStorage();   //--> it will cause error before.
```
