### PR TITLE
Recommend npx pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ $ yarn add @react-native-community/async-storage
 
 [CLI autolink feature](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) links the module while building the app. 
 
-Run `pod install` in iOS project in order to add RNAsyncStorage cocoapod:
+Use CocoaPods to add the native `RNAsyncStorage` to your project:
 
 ```bash
-$ cd ios && pod install
+$ npx pod-install
 ```
 
 - **React Native <= 0.59**


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`