### PR TITLE
fix Pods installation on macOS

### DIFF
--- a/RNCAsyncStorage.podspec
+++ b/RNCAsyncStorage.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-async-storage.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
# Overview

Refs #296

This small PR updates the `podspec` file and adds `osx` platform there which fixed Pods installation on macOS:

<img width="1107" alt="Screenshot 2020-05-22 at 00 42 42" src="https://user-images.githubusercontent.com/719641/82613264-2a5fb780-9bc5-11ea-905d-01eb3e073adf.png">


# Test Plan

I have tested the change on the local working copy of `async-storage`.