### PR TITLE
fix: target built version in react-native package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "react-native": "src/index.js",
+  "react-native": "lib/module/index.js",
   "types": "./types/index.d.ts",
   "files": [
     "lib/",


### PR DESCRIPTION
Thanks for the great lib!

Summary:
---------

I bumped into an issue similar to https://github.com/react-native-community/async-storage/issues/339 , but reproducing in React Native:

<img width="541" alt="Screen Shot 2020-05-21 at 12 29 41" src="https://user-images.githubusercontent.com/381614/82550434-cdc9b180-9b5e-11ea-9f48-db18afd68e4d.png">

The root of the issue turned to be that the `react-native` field in the `package.json` is pointing to the `src/index.js` file, which contains syntax that my bundler does not recognize. I pointed the `react-native` field to `lib/module/index.js` instead and all is working as expected.

In order to minimize the assumptions about consumer bundle configurations, I think it'd be ideal to treat `react-native` the same as web and point it to the built version, this PR is to do just that.

Test Plan:
----------

I prepared a repo with the demonstration of the issue and of the fix:

https://github.com/xaviervia/test-async-storage

To reproduce: 

1. `git clone git@github.com:xaviervia/test-async-storage && cd test-async-storage`
2. Run `yarn`
3. Run `yarn start app ios` or `yarn start app android` (either will demonstrate the issue and show the red screen of death)

To test the fix:

1. Run `yarn start patchAsyncStorage` . This will replace the package.json entry `"react-native": "src/index.js",` with `"react-native": "lib/module/index.js",` in the `@react-native-community/async-storage` package json file.
2. Run again either `yarn start app ios` or `yarn start app android`
