### PR TITLE
Swap the native module used when in Expo managed workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Expo managed workflow supported native backend
+/src/RCTAsyncStorage.expo.js @brentvatne

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/async-storage",
-  "version": "1.11.0-alpha.0",
+  "version": "1.10.3",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/async-storage",
-  "version": "1.10.3",
+  "version": "1.11.0-alpha.0",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/src/AsyncStorage.native.js
+++ b/src/AsyncStorage.native.js
@@ -11,12 +11,7 @@
 
 'use strict';
 
-const {NativeModules} = require('react-native');
-
-const RCTAsyncStorage =
-  NativeModules.PlatformLocalStorage || // Support for external modules, like react-native-windows
-  NativeModules.RNC_AsyncSQLiteDBStorage ||
-  NativeModules.RNCAsyncStorage;
+import RCTAsyncStorage from './RCTAsyncStorage';
 
 if (!RCTAsyncStorage) {
   throw new Error(`[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null.

--- a/src/RCTAsyncStorage.expo.js
+++ b/src/RCTAsyncStorage.expo.js
@@ -1,0 +1,13 @@
+/**
+ * Expo managed apps don't include the @react-native-community/async-storage
+ * native modules yet, but the API interface is the same, so we can use the version
+ * exported from React Native still.
+ *
+ * If in future releases (eg: @react-native-community/async-storage >= 2.0.0) this
+ * will likely not be valid anymore, and the package will need to be included in the Expo SDK
+ * to continue to work.
+ */
+const {NativeModules} = require('react-native');
+const RCTAsyncStorage = NativeModules.AsyncSQLiteDBStorage || NativeModules.AsyncLocalStorage;
+
+export default RCTAsyncStorage;

--- a/src/RCTAsyncStorage.js
+++ b/src/RCTAsyncStorage.js
@@ -1,0 +1,8 @@
+const {NativeModules} = require('react-native');
+
+const RCTAsyncStorage =
+  NativeModules.PlatformLocalStorage || // Support for external modules, like react-native-windows
+  NativeModules.RNC_AsyncSQLiteDBStorage ||
+  NativeModules.RNCAsyncStorage;
+
+export default RCTAsyncStorage;


### PR DESCRIPTION
Summary:
---------

Currently tools like AWS Amplify and redux-persist need separate instructions for using AsyncStorage whether you are in an Expo managed project or a bare React Native project, because Expo manage projects do not yet include @react-native-community/async-storage. We would like to include it, but it's a bit trickier than most packages due to complexity around scoping storage access when switching between different projects within the Expo client app.

In order to let library authors just tell people to use @react-native-community/async-storage, I think the easiest solution for now is to swap out the backing native module when in the Expo managed workflow to the solution provided by React Native, which is still included in core as recently as 0.62.2. I did this by moving out the logic for picking which native module to use into `RCTAsyncStorage.js` and `RCTAsyncStorage.expo.js`. The `.expo.js` extension is only used in the Expo managed workflow ([more info if you're curious](https://docs.expo.io/bare/using-expo-client/#use-the-expojsjsontstsx-extension-to-provide-expo)).

As far as I can tell, the API interface is the same and this should not cause any issues. When we update to 0.63 we will likely investigate what it will take to fully integrate this library.

**The changes here have no impact on any environment other than Expo managed projects.**

Test Plan:
----------

To make this very easy to test I published an alpha version of the package: `@react-native-community/async-storage@1.11.0-alpha.0`.

You can test that this works in Expo managed apps by running the following:
- `npx crna --template blank`
- Install `@react-native-community/async-storage@1.11.0-alpha.0`
- Copy in the ["useAsyncStorage Specific Example"](https://github.com/react-native-community/async-storage/blob/master/docs/API.md#useasyncstorage) into App.js
- `yarn ios` and/or `yarn android`
- Import it in the app and use it

And in a bare React Native app:
- `npx react-native init`
- Install `@react-native-community/async-storage@1.11.0-alpha.0`
- `npx pod-install`
- Copy in the ["useAsyncStorage Specific Example"](https://github.com/react-native-community/async-storage/blob/master/docs/API.md#useasyncstorage) into App.js
- `yarn ios` and/or `yarn android`
- Import it in the app and use it