### PR TITLE
fix test:lint command on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:e2e:macos": "scripts/run_macos_e2e.sh 'build'",
     "test": "yarn test:lint && yarn test:flow",
     "test:flow": "flow check",
-    "test:lint": "eslint 'src/**/*.js' 'example/**/*.js' 'jest/*.js'",
+    "test:lint": "eslint src/**/*.js example/**/*.js jest/*.js",
     "test:e2e:ios": "detox test -c ios",
     "test:e2e:android": "detox test -c android",
     "test:e2e:macos": "scripts/run_macos_e2e.sh 'test'"


### PR DESCRIPTION
Summary:
---------

This small PR fixes `test:lint` command on Windows by removing single single quotes (they can be also replaced with the escaped double quotes, but removal is a simpler solution).

> ...you have to quote your parameter (using double quotes if you need it to run in Windows)...

More information [here](https://eslint.org/docs/user-guide/command-line-interface).

### Preview

<img width="388" alt="Annotation 2020-06-19 132104" src="https://user-images.githubusercontent.com/719641/85127468-c49c3500-b22f-11ea-86d0-a3182035aa57.png">


Test Plan:
----------

`test:lint` run has been successful after the change.  Tested on the macOS and Windows.