### PR TITLE
remove deep-assign dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
     "react": "^16.8",
     "react-native": ">=0.59"
   },
-  "dependencies": {
-    "deep-assign": "^3.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",

--- a/src/AsyncStorage.js
+++ b/src/AsyncStorage.js
@@ -8,13 +8,20 @@
  * @flow
  */
 
-import merge from 'deep-assign';
+const merge = (target, source) => {
+  for (const key of Object.keys(source)) {
+    if (source[key] instanceof Object) {
+      Object.assign(source[key], merge(target[key], source[key]));
+    }
+  }
+  return Object.assign({}, target || {}, source);
+};
 
 const mergeLocalStorageItem = (key, value) => {
   const oldValue = window.localStorage.getItem(key);
   const oldObject = JSON.parse(oldValue);
   const newObject = JSON.parse(value);
-  const nextValue = JSON.stringify(merge({}, oldObject, newObject));
+  const nextValue = JSON.stringify(merge(oldObject, newObject));
   window.localStorage.setItem(key, nextValue);
 };
 

--- a/src/AsyncStorage.js
+++ b/src/AsyncStorage.js
@@ -8,13 +8,15 @@
  * @flow
  */
 
-const merge = (target, source) => {
+const merge = (target = {}, source = {}) => {
   for (const key of Object.keys(source)) {
     if (source[key] instanceof Object) {
       Object.assign(source[key], merge(target[key], source[key]));
+    } else {
+      source[key] = target[key] || source[key];
     }
   }
-  return Object.assign({}, target || {}, source);
+  return Object.assign(target, source);
 };
 
 const mergeLocalStorageItem = (key, value) => {


### PR DESCRIPTION
Summary:
---------

Fixes #374 

<img width="995" alt="Screenshot_2020-06-19_at_00 32 05" src="https://user-images.githubusercontent.com/719641/85131505-3b88fc00-b237-11ea-80c5-ccfe789dba92.png">

This PR removes deprecated `deep-assign` package dependency and replaces its functionality with the simple native ES code.

Since there is only one place where this method is used and it is a simple usage I have decided to not implement `target` as [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) argument.

I'm happy to improve/put more work into this PR if it's needed.

Test Plan:
----------

From the several tests I have conducted for all of the cases the result of `deep-assign` and new `merge` function were exactly the same.

Snack playground:
* https://snack.expo.io/@simek/courageous-bubblegum