### PR TITLE
Fix link to Mock Implementation [DOCS]

### DIFF
--- a/website/docs/advanced/Jest-integration.md
+++ b/website/docs/advanced/Jest-integration.md
@@ -66,4 +66,4 @@ AsyncStorageMock.multiGet = jest.fn(([keys], callback) => {
 export default AsyncStorageMock;
 ```
 
-You can [check its implementation](../jest/async-storage-mock.js) to get more insight into methods signatures.
+You can [check its implementation](https://github.com/react-native-community/async-storage/blob/master/jest/async-storage-mock.js) to get more insight into methods signatures.


### PR DESCRIPTION


Summary:
---------

At the moment in Jest Integration if you try to access the link to AsyncStorageMock implementation you will get a 404 since the link currently is : `https://github.com/react-native-community/async-storage/blob/master/website/docs/jest/async-storage-mock.js`.

The new right link should be : https://github.com/react-native-community/async-storage/blob/master/jest/async-storage-mock.js.

This link change should fix the issue.


Test Plan:
----------

Test plan should be checking if the link now redirects to the right page.