### PR TITLE
Fix typographical error

### DIFF
--- a/website/docs/advanced/Jest-integration.md
+++ b/website/docs/advanced/Jest-integration.md
@@ -5,7 +5,7 @@ sidebar_label: Jest integration
 ---
 
 
-Async Storage module is tightly coupled with its `NativeModule` part - it needs a running React Native application to work properly. In order to use it in tests, you have to provide its separate implementation. Follow those steps to add a mocked `Async Storage` module.
+Async Storage module is tightly coupled with its `NativeModule` part - it needs a running React Native application to work properly. In order to use it in tests, you have to provide its separate implementation. Follow these steps to add a mocked `Async Storage` module.
 
 ## Using Async Storage mock
 


### PR DESCRIPTION
In the sentence 'Follow those steps to add a mocked `Async Storage` module', these should be used in place of those.
