### PR TITLE
Native Module refreshment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,14 @@ jobs:
           name: Flow check
           command: yarn test:flow
 
+  "Test: units":
+    <<: *js_defaults
+    steps:
+      - *addWorkspace
+      - run:
+          name: Unit tests
+          command: yarn test:unit
+
   "Test: iOS e2e":
     <<: *macos_defaults
     steps:
@@ -306,14 +314,19 @@ workflows:
       - "Test: flow":
           requires:
             - "Setup environment"
+      - "Test: units":
+          requires:
+            - "Setup environment"
       - "Test: iOS e2e":
           requires:
             - "Test: lint"
             - "Test: flow"
+            - "Test: units"
       - "Build: Android release apk":
           requires:
             - "Test: lint"
             - "Test: flow"
+            - "Test: units"
 #      - "Test: Android e2e":
 #          requires:
 #            - "Test: lint"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,19 +2,42 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def useDedicatedExecutor = rootProject.hasProperty('AsyncStorage_dedicatedExecutor')
+        ? rootProject.properties['AsyncStorage_dedicatedExecutor']
+        : false
+
+
 buildscript {
-    // The Android Gradle plugin is only required when opening the android folder stand-alone.
-    // This avoids unnecessary downloads and potential conflicts when the library is included as a
-    // module dependency in an application project.
-    if (project == rootProject) {
-        repositories {
-            google()
+    def isRootProject = project == rootProject
+
+    ext.ktCoroutinesVersion = "1.3.8"
+
+    // kotlin version can be set by setting ext.kotlinVersion or having it in gradle.properties in root
+    ext.asyncStorageKtVersion = rootProject.ext.has('kotlinVersion')
+            ? rootProject.ext.get('kotlinVersion')
+            : properties['kotlinVersion']
+            ? properties['kotlinVersion']
+            : "1.3.72"
+
+    repositories {
+        if (isRootProject) {
             jcenter()
         }
-        dependencies {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
+        if (isRootProject) {
+            // The Android Gradle plugin is only required when opening the android folder stand-alone.
+            // This avoids unnecessary downloads and potential conflicts when the library is included as a
+            // module dependency in an application project.
             classpath 'com.android.tools.build:gradle:3.5.0'
         }
     }
+
+
 }
 
 // AsyncStorage has default size of 6MB.
@@ -24,16 +47,12 @@ buildscript {
 long dbSizeInMB = 6L
 
 def newDbSize = rootProject.properties['AsyncStorage_db_size_in_MB']
-
-if( newDbSize != null && newDbSize.isLong()) {
+if (newDbSize != null && newDbSize.isLong()) {
     dbSizeInMB = newDbSize.toLong()
 }
 
-def useDedicatedExecutor = rootProject.hasProperty('AsyncStorage_dedicatedExecutor')
-        ? rootProject.properties['AsyncStorage_dedicatedExecutor']
-        : false
-
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -62,4 +81,6 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$asyncStorageKtVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$ktCoroutinesVersion"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,8 @@ def useDedicatedExecutor = rootProject.hasProperty('AsyncStorage_dedicatedExecut
 buildscript {
     def isRootProject = project == rootProject
 
-    ext.ktCoroutinesVersion = "1.3.8"
+    ext.coroutinesVersion = "1.3.8"
+    ext.roomVersion = "2.2.5"
 
     // kotlin version can be set by setting ext.kotlinVersion or having it in gradle.properties in root
     ext.asyncStorageKtVersion = rootProject.ext.has('kotlinVersion')
@@ -53,6 +54,7 @@ if (newDbSize != null && newDbSize.isLong()) {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -81,6 +83,11 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
+    //noinspection GradleDependency
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$asyncStorageKtVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$ktCoroutinesVersion"
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "androidx.room:room-runtime:$roomVersion"
+    implementation "androidx.room:room-ktx:$roomVersion"
+    kapt "androidx.room:room-compiler:$roomVersion"
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -16,11 +16,15 @@ import com.facebook.react.uimanager.ViewManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.reactnativecommunity.asyncstorage.next.AsyncStorageModuleNext;
 
 public class AsyncStoragePackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new AsyncStorageModule(reactContext));
+      return Arrays.<NativeModule>asList(
+              new AsyncStorageModule(reactContext),
+              new AsyncStorageModuleNext(reactContext)
+      );
     }
 
     // Deprecated in RN 0.47 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/AsyncStorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/AsyncStorageModule.kt
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+class AsyncStorageModuleNext(reactAppContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactAppContext), CoroutineScope {
+  companion object {
+    const val MODULE_NAME = "RNC_AsyncStorageNext"
+  }
+
+  override val coroutineContext: CoroutineContext
+    get() = Dispatchers.IO + CoroutineName("AsyncStorageCoroutine")
+
+  private val db: ASDao
+    get() = AsyncStorageDB.getDatabase(reactApplicationContext).getASDao()
+
+  override fun getName() = MODULE_NAME
+
+  @ReactMethod
+  fun getSingle(key: String, promise: Promise) {
+    launch {
+      val value = db.get(key)
+      promise.resolve(value)
+    }
+  }
+
+  @ReactMethod
+  fun setSingle(key: String, value: String?, promise: Promise) {
+    val entry = AsyncStorageEntry(key, value)
+    launch {
+      db.set(entry)
+      promise.resolve(true)
+    }
+  }
+
+  @ReactMethod
+  fun deleteSingle(key: String, promise: Promise) {
+    val entry = AsyncStorageEntry(key)
+    launch {
+      db.delete(entry)
+      promise.resolve(true)
+    }
+  }
+
+  @ReactMethod
+  fun getMany(keys: ReadableArray, promise: Promise) {
+    val queryKeys = keys.toKeyList()
+
+    launch {
+      val entries = db.getMany(queryKeys).toReadableMap()
+      promise.resolve(entries)
+    }
+  }
+
+  @ReactMethod
+  fun setMany(entries: ReadableMap, promise: Promise) {
+    val entryList = entries.toAsyncStorageEntries()
+
+    launch {
+      db.setMany(entryList)
+      promise.resolve(true)
+    }
+  }
+
+  @ReactMethod
+  fun deleteMany(keys: ReadableArray, promise: Promise) {
+    val keysToDelete = keys.toKeyList()
+
+    launch {
+      db.deleteMany(keysToDelete)
+      promise.resolve(true)
+    }
+  }
+
+  @ReactMethod
+  fun getAllKeys(promise: Promise) {
+    launch {
+      val keys = db.keys().toReadableArray()
+      promise.resolve(keys)
+    }
+  }
+
+  @ReactMethod
+  fun dropDatabase(promise: Promise) {
+    launch {
+      db.dropDatabase()
+      promise.resolve(true)
+    }
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/DatabaseSchema.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/DatabaseSchema.kt
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.asyncstorage.next
+
+import android.content.Context
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Delete
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+typealias KeyType = String
+typealias ValueType = String?
+
+// todo: change those to use old DB
+// todo: unit tests
+const val DB_NAME = "AsyncStorageNextDB"
+const val DB_VERSION = 1
+const val TABLE_NAME = "as_table"
+const val KEY_COLUMN = "as_keys"
+const val VALUE_COLUMN = "as_value"
+
+// The only table in this DB
+
+@Entity(tableName = TABLE_NAME)
+data class AsyncStorageEntry(
+  @PrimaryKey
+  @ColumnInfo(name = KEY_COLUMN)
+  val key: String,
+  @ColumnInfo(name = VALUE_COLUMN)
+  val value: String? = null
+)
+
+@Dao
+interface ASDao {
+
+  @Query("SELECT $VALUE_COLUMN FROM $TABLE_NAME WHERE $KEY_COLUMN = :key")
+  suspend fun get(key: KeyType): ValueType
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun set(entry: AsyncStorageEntry)
+
+  @Delete
+  suspend fun delete(entry: AsyncStorageEntry)
+
+  @Query("SELECT $KEY_COLUMN FROM $TABLE_NAME")
+  suspend fun keys(): List<KeyType>
+
+  @Query("DELETE from $TABLE_NAME")
+  suspend fun dropDatabase()
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun setMany(entries: List<AsyncStorageEntry>)
+
+  @Query("SELECT * FROM $TABLE_NAME WHERE $KEY_COLUMN in (:keys)")
+  suspend fun getMany(keys: List<KeyType>): List<AsyncStorageEntry>
+
+  @Query("DELETE FROM $TABLE_NAME WHERE $KEY_COLUMN in (:keys)")
+  suspend fun deleteMany(keys: List<KeyType>)
+}
+
+@Database(entities = [AsyncStorageEntry::class], version = DB_VERSION)
+abstract class AsyncStorageDB : RoomDatabase() {
+
+  companion object {
+    private var instance: AsyncStorageDB? = null
+
+    fun getDatabase(context: Context): AsyncStorageDB {
+
+      var inst = instance
+
+      if (inst != null) {
+        return inst
+      }
+      synchronized(this) {
+        inst = Room
+          .databaseBuilder(context, AsyncStorageDB::class.java, DB_NAME)
+          .build()
+
+        instance = inst
+        return instance!!
+      }
+    }
+  }
+
+  abstract fun getASDao(): ASDao
+}
+

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/Utils.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/Utils.kt
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+
+fun ReadableArray.toKeyList(): List<String> {
+  val keys: MutableList<String> = mutableListOf()
+  for (index in 0 until this.size()) {
+    val key = getString(index)
+    if (key != null) {
+      keys.add(key)
+    }
+  }
+  return keys
+}
+
+fun ReadableMap.toAsyncStorageEntries(): List<AsyncStorageEntry> {
+  val entryList = mutableListOf<AsyncStorageEntry>()
+  val keyIterator = keySetIterator()
+  while (keyIterator.hasNextKey()) {
+    val key = keyIterator.nextKey()
+    val value = getString(key)
+    entryList.add(AsyncStorageEntry(key, value))
+  }
+  return entryList
+}
+
+fun List<KeyType>.toReadableArray(): ReadableArray {
+  val keyArray = Arguments.createArray()
+  forEach { key ->
+    keyArray.pushString(key)
+  }
+  return keyArray
+}
+
+fun List<AsyncStorageEntry>.toReadableMap(): ReadableMap {
+  val result = Arguments.createMap()
+  forEach {
+    result.putString(it.key, it.value)
+  }
+  return result
+}

--- a/example/App.js
+++ b/example/App.js
@@ -21,6 +21,7 @@ import {
 
 import GetSetClear from './examples/GetSetClear';
 import MergeItem from './examples/MergeItem';
+import AsyncStorageNext from './examples/Next';
 
 const TESTS = {
   GetSetClear: {
@@ -37,6 +38,14 @@ const TESTS = {
     description: 'Merge object with already stored data',
     render() {
       return <MergeItem />;
+    },
+  },
+  Next: {
+    title: 'Next AsyncStorage',
+    testId: 'as-next',
+    description: 'Use Next version of AsyncStorage',
+    render() {
+      return <AsyncStorageNext />;
     },
   },
 };
@@ -86,6 +95,11 @@ export default class App extends Component<Props, State> {
             testID="testType_mergeItem"
             title="Merge Item"
             onPress={() => this._changeTest('MergeItem')}
+          />
+          <Button
+            testID="testType_next"
+            title="Next"
+            onPress={() => this._changeTest('Next')}
           />
         </View>
 

--- a/example/examples/Next.js
+++ b/example/examples/Next.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+import {Button, StyleSheet, Text, View} from 'react-native';
+import {AsyncStorageNext} from '@react-native-community/async-storage';
+import {STORAGE_KEY} from './GetSetClear';
+
+export default function NextExample() {
+  const [storedNumber, setStoredNumber] = React.useState(0);
+  const [needRestart, setNeedRestart] = React.useState(false);
+
+  const increaseByTen = async () => {
+    const newNumber = +storedNumber > 0 ? +storedNumber + 10 : 10;
+
+    await AsyncStorageNext.setItem(STORAGE_KEY, `${newNumber}`);
+    await AsyncStorageNext.setItem(`${STORAGE_KEY}_2`, `${newNumber}`);
+    await AsyncStorageNext.setItem(`${STORAGE_KEY}_3`, `${newNumber}`);
+    await AsyncStorageNext.setItem(`${STORAGE_KEY}_4`, `${newNumber}`);
+    setStoredNumber(newNumber);
+    setNeedRestart(true);
+  };
+
+  const clearItem = async () => {
+    await AsyncStorageNext.removeItem(STORAGE_KEY);
+
+    setNeedRestart(true);
+  };
+
+  const displayKeys = async () => {
+    const keys = await AsyncStorageNext.getAllKeys();
+    alert(keys);
+  };
+
+  const dropDP = async () => {
+    await AsyncStorageNext.clear();
+  };
+
+  const deleteMany = async () => {
+    await AsyncStorageNext.multiRemove([
+      'value1',
+      'value2',
+      'value3',
+      'value4',
+    ]);
+  };
+
+  const setMany = async () => {
+    const values = {
+      value1: '' + Math.floor(Math.random() * 100),
+      value2: '' + Math.floor(Math.random() * 100),
+      value3: '' + Math.floor(Math.random() * 100),
+      value4: '' + Math.floor(Math.random() * 100),
+    };
+
+    await AsyncStorageNext.multiSet(values);
+  };
+
+  const getMany = async () => {
+    const results = await AsyncStorageNext.multiGet([
+      'value1',
+      'value2',
+      'value3',
+      'value4',
+    ]);
+
+    alert(JSON.stringify(results));
+  };
+
+  React.useEffect(() => {
+    (async () => {
+      const value = await AsyncStorageNext.getItem(STORAGE_KEY);
+      setStoredNumber(value || 0);
+    })();
+  }, []);
+
+  return (
+    <View>
+      <Text style={styles.text}>Currently stored: </Text>
+      <Text testID="storedNumber_text" style={styles.text}>
+        {storedNumber}
+      </Text>
+
+      <Button
+        testID="increaseByTen_button"
+        title="Increase by 10"
+        onPress={increaseByTen}
+      />
+
+      <Button testID="clear_button" title="Delete item" onPress={clearItem} />
+
+      <Button
+        testID="increaseByTen_button"
+        title="get all keys"
+        onPress={displayKeys}
+      />
+      <Button title="Drop DB" onPress={dropDP} />
+      <Button title="Set many" onPress={setMany} />
+      <Button title="Get many" onPress={getMany} />
+      <Button title="Delete many" onPress={deleteMany} />
+
+      {needRestart ? <Text>Hit restart to see effect</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+});

--- a/example/jest.setup.js
+++ b/example/jest.setup.js
@@ -1,7 +1,0 @@
-/**
- * @format
- */
-
-import mockAsyncStorage from '../jest/async-storage-mock';
-
-jest.mock('@react-native-community/async-storage', () => mockAsyncStorage);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test": "yarn test:lint && yarn test:flow",
     "test:flow": "flow check",
     "test:lint": "eslint src/**/*.js example/**/*.js jest/*.js",
+    "test:unit": "jest",
     "test:e2e:ios": "detox test -c ios",
     "test:e2e:android": "detox test -c android",
     "test:e2e:macos": "scripts/run_macos_e2e.sh 'test'"
@@ -86,10 +87,7 @@
     "react-test-renderer": "16.9.0"
   },
   "jest": {
-    "preset": "react-native",
-    "setupFiles": [
-      "./example/jest.setup.js"
-    ]
+    "preset": "react-native"
   },
   "detox": {
     "test-runner": "jest",

--- a/src/__mocks__/RCTAsyncStorage.js
+++ b/src/__mocks__/RCTAsyncStorage.js
@@ -1,0 +1,84 @@
+/**
+ * @format
+ * @flow
+ */
+import merge from 'deep-assign';
+
+let __storage = {};
+
+const AsyncStorageNativeModuleFake = {
+  multiGet(keys: string[], cb: (?Object, ?(string[][])) => void) {
+    if (!keys) {
+      cb({message: 'No keys provided'});
+    }
+
+    const keysValues = keys.reduce(
+      (acc, key) => [...acc, [key, __storage[key]]],
+      [],
+    );
+
+    // error, value
+    cb(null, keysValues);
+  },
+
+  multiSet(keyValues: string[][], cb: (?Object) => void) {
+    if (!keyValues) {
+      cb({message: 'no keys provided'});
+    }
+    try {
+      keyValues.forEach(pair => {
+        if (!pair[0] === undefined || !pair[1] === undefined) {
+          throw 'pairs not matching';
+        }
+        __storage[pair[0]] = pair[1];
+      });
+    } catch (e) {
+      cb({message: e});
+    }
+    cb();
+  },
+
+  multiRemove(keys: string[], cb: (?Object) => void) {
+    if (!keys) {
+      cb({message: 'keys not provided'});
+    }
+    keys.forEach(k => {
+      delete __storage[k];
+    });
+
+    cb();
+  },
+
+  multiMerge(keyValues: string[], cb: (?Object) => void) {
+    if (!keyValues) {
+      cb({message: 'keys not provided'});
+    }
+
+    try {
+      keyValues.forEach(pair => {
+        if (!pair[0] || !pair[1]) {
+          throw 'pairs not matching';
+        }
+
+        const storedValue = __storage[pair[0]];
+        const merged = merge({}, JSON.parse(storedValue), JSON.parse(pair[1]));
+
+        __storage[pair[0]] = JSON.stringify(merged);
+      });
+
+      cb();
+    } catch (e) {
+      cb({message: e});
+    }
+
+    cb();
+  },
+
+  clear(cb: (?Object) => void) {
+    __storage = {};
+
+    cb();
+  },
+};
+
+export default AsyncStorageNativeModuleFake;

--- a/src/__tests__/AsyncStorage.js
+++ b/src/__tests__/AsyncStorage.js
@@ -4,13 +4,14 @@
 /* eslint-disable no-shadow */
 
 import 'react-native';
+import AsyncStorage from '../AsyncStorage.native';
 
-import AsyncStorage from '@react-native-community/async-storage';
+jest.mock('../RCTAsyncStorage');
 
 describe('Async Storage mock functionality', () => {
   describe('Promise based', () => {
     it('can read/write data to/from storage', async () => {
-      const newData = Math.floor(Math.random() * 1000);
+      const newData = String(Math.floor(Math.random() * 1000));
 
       await AsyncStorage.setItem('key', newData);
 
@@ -20,7 +21,7 @@ describe('Async Storage mock functionality', () => {
     });
 
     it('can clear storage', async () => {
-      await AsyncStorage.setItem('temp_key', Math.random() * 1000);
+      await AsyncStorage.setItem('temp_key', String(Math.random() * 1000));
 
       let currentValue = await AsyncStorage.getItem('temp_key');
 
@@ -34,8 +35,8 @@ describe('Async Storage mock functionality', () => {
     });
 
     it('can clear entries in storage', async () => {
-      await AsyncStorage.setItem('random1', Math.random() * 1000);
-      await AsyncStorage.setItem('random2', Math.random() * 1000);
+      await AsyncStorage.setItem('random1', String(Math.random() * 1000));
+      await AsyncStorage.setItem('random2', String(Math.random() * 1000));
 
       let data1 = await AsyncStorage.getItem('random1');
       let data2 = await AsyncStorage.getItem('random2');
@@ -80,7 +81,7 @@ describe('Async Storage mock functionality', () => {
 
   describe('Callback based', () => {
     it('can read/write data to/from storage', done => {
-      const newData = Math.floor(Math.random() * 1000);
+      const newData = String(Math.floor(Math.random() * 1000));
 
       AsyncStorage.setItem('key', newData, function() {
         AsyncStorage.getItem('key', function(_, value) {
@@ -90,7 +91,7 @@ describe('Async Storage mock functionality', () => {
       });
     });
     it('can clear storage', done => {
-      AsyncStorage.setItem('temp_key', Math.random() * 1000, () => {
+      AsyncStorage.setItem('temp_key', String(Math.random() * 1000), () => {
         AsyncStorage.getItem('temp_key', (_, currentValue) => {
           expect(currentValue).not.toBeNull();
           AsyncStorage.clear(() => {
@@ -104,8 +105,8 @@ describe('Async Storage mock functionality', () => {
     });
 
     it('can clear entries in storage', done => {
-      AsyncStorage.setItem('random1', Math.random() * 1000, () => {
-        AsyncStorage.setItem('random2', Math.random() * 1000, () => {
+      AsyncStorage.setItem('random1', String(Math.random() * 1000), () => {
+        AsyncStorage.setItem('random2', String(Math.random() * 1000), () => {
           AsyncStorage.getItem('random1', (_, data1) => {
             AsyncStorage.getItem('random2', (_, data2) => {
               expect(data1).not.toBeNull();

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
  */
 
 import AsyncStorage from './AsyncStorage';
+import AsyncStorageNext from './next/AsyncStorage';
 
 export default AsyncStorage;
 export {useAsyncStorage} from './hooks';
+export {AsyncStorageNext};

--- a/src/next/AsyncStorage.js
+++ b/src/next/AsyncStorage.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+
+import ASNativeModule from './NativeModule';
+import type {EntryType, KeyType, ValueType} from './NativeModule';
+
+
+/**
+ todo:
+ 1. Match public API
+ 2. Merge API implementation
+ */
+class AsyncStorage {
+
+  /**
+   * Read a value for given 'key'
+   */
+  async getItem(key: KeyType): Promise<ValueType> {
+    return ASNativeModule.getSingle(key);
+  }
+
+  /**
+   * Saves 'value' for given 'key'
+   */
+  async setItem(key: KeyType, value: ValueType): Promise<boolean> {
+    return ASNativeModule.setSingle(key, value);
+  }
+
+  /**
+   * Remove entry for given 'key'
+   */
+  async removeItem(key: KeyType): Promise<boolean> {
+    return ASNativeModule.deleteSingle(key);
+  }
+
+  /**
+   * Reads values for given list of keys
+   */
+  async multiGet(keys: KeyType[]): Promise<EntryType> {
+    return ASNativeModule.getMany(keys);
+  }
+
+  /**
+   * Save multiple entry in one batch
+   */
+  async multiSet(entry: EntryType): Promise<boolean> {
+    return ASNativeModule.setMany(entry);
+  }
+
+  /**
+   * remove multiple items in one batch
+   */
+  async multiRemove(keys: KeyType[]): Promise<boolean> {
+    return ASNativeModule.deleteMany(keys);
+  }
+
+  /**
+   * Returns all keys used to store data
+   */
+  async getAllKeys(): Promise<KeyType[]> {
+    return ASNativeModule.getAllKeys();
+  }
+
+  /**
+   * Removes all values from database
+   */
+  async clear(): Promise<boolean> {
+    return ASNativeModule.dropDatabase();
+  }
+
+}
+
+export default new AsyncStorage();

--- a/src/next/NativeModule.js
+++ b/src/next/NativeModule.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Krzysztof Borowy
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {NativeModules} from 'react-native';
+
+export type KeyType = String;
+export type ValueType = String | null;
+export type EntryType = {[key: KeyType]: ValueType};
+
+type ASNativeModuleType = {
+  getSingle: (key: KeyType) => Promise<ValueType>,
+  setSingle: (key: KeyType, value: ValueType) => Promise<boolean>,
+  deleteSingle: (key: KeyType) => Promise<boolean>,
+
+  getMany: (keys: KeyType[]) => Promise<EntryType>,
+  setMany: (EntryType) => Promise<boolean>,
+  deleteMany: (keys: KeyType[]) => Promise<boolean>,
+
+  getAllKeys: () => Promise<KeyType[]>,
+  dropDatabase: () => Promise<boolean>
+}
+
+const ASNative: ASNativeModuleType = NativeModules.RNC_AsyncStorageNext;
+
+if (!ASNative) {
+  /**
+   * Native Module is not linked properly
+   * We need to notify dev about it
+   */
+  throw new Error('AsyncStorage\'s NativeModule is not linked.');
+}
+
+export default ASNative;


### PR DESCRIPTION
Summary:
---------

Here comes the time to refresh the Native Module used by Android. Instead using error prone `SQLiteOpenHelper`, [Room](https://developer.android.com/topic/libraries/architecture/room) + Coroutines are used. This will help with dealing with [all regarding accessing db ](https://github.com/react-native-community/async-storage/issues/355)  and ease implementation of new features, such as [accessing DB from Native Side](https://github.com/react-native-community/async-storage/issues/238) and others.
 
Todo Plan:
----------

- [ ] Match API for JS module
- [ ] Implement Merge/mutliMerge API on JS side for new module
- [ ] Replace old Native Android module with this new one
- [ ] Refresh Example App
- [x] Write unit tests for native and js module (add them to CI)
- [ ] Add other todo I forgot



Test Plan:
----------

1. Green UI tests 
2. Would be great to have integration tests too 🤞 
