### PR TITLE
Add support for enabled TurboModules in Expo

### DIFF
--- a/src/RCTAsyncStorage.expo.js
+++ b/src/RCTAsyncStorage.expo.js
@@ -7,7 +7,18 @@
  * will likely not be valid anymore, and the package will need to be included in the Expo SDK
  * to continue to work.
  */
-const {NativeModules} = require('react-native');
-const RCTAsyncStorage = NativeModules.AsyncSQLiteDBStorage || NativeModules.AsyncLocalStorage;
+const {NativeModules, TurboModuleRegistry} = require('react-native');
+
+let RCTAsyncStorage;
+
+// TurboModuleRegistry falls back to NativeModules
+// so we don't have to try go assign NativeModules'
+// counterparts if TurboModuleRegistry would resolve
+// with undefined.
+if (TurboModuleRegistry) {
+  RCTAsyncStorage = TurboModuleRegistry.get("AsyncSQLiteDBStorage") || TurboModuleRegistry.get("AsyncLocalStorage");
+} else {
+  RCTAsyncStorage = NativeModules.AsyncSQLiteDBStorage || NativeModules.AsyncLocalStorage;
+}
 
 export default RCTAsyncStorage;


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->

At Expo we're on the verge of enabling TurboModules in SDK 39 (https://github.com/expo/expo/pull/9687). While we haven't added the native code for this module to the SDK yet, we want to maintain the `.expo.js` fallback, so it resolves with the React Native's `AsyncStorage`.


Test Plan:
----------

I have verified manually that copying and pasting this code to an appropriate file in `node_modules` for a running Expo project fixes the `[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null.` error.

The `if (TurboModuleRegistry)` helps to not break this code on older versions of RN which do not have TMR (I hope).

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->