### PR TITLE
docs: fixed relative links

### DIFF
--- a/website/docs/Installation.md
+++ b/website/docs/Installation.md
@@ -31,4 +31,4 @@ npx pod-install
 react-native link @react-native-community/async-storage
 ```
 
-*Note:* For `Windows` the [manual linking](link) is currently the only linking option.
+*Note:* For `Windows` the [manual linking](Linking.md) is currently the only linking option.

--- a/website/docs/Usage.md
+++ b/website/docs/Usage.md
@@ -79,5 +79,5 @@ const getData = async () => {
 
 ### More
 
-For more examples, [head over to API section.](api)
+For more examples, [head over to API section.](API.md)
 


### PR DESCRIPTION
Summary:
---------
Closes #398

Relative links now work even if there's a `/` at the end of URL.

This issue was related to https://github.com/facebook/docusaurus/issues/2298


Test Plan:
----------

Go to https://react-native-community.github.io/async-storage/docs/usage/ and click on "head over to API section"

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->