### PR TITLE
fix: Errors reported from getAllKeys/clear [WINDOWS]

### DIFF
--- a/windows/ReactNativeAsyncStorage/DBStorage.cpp
+++ b/windows/ReactNativeAsyncStorage/DBStorage.cpp
@@ -469,7 +469,7 @@ void DBStorage::DBTask::getAllKeys(sqlite3* db) {
         auto writer = winrt::MakeJSValueTreeWriter();
         result.WriteTo(writer);
         std::vector<winrt::JSValue> callbackParams;
-        callbackParams.push_back(winrt::JSValueArray());
+        callbackParams.push_back(nullptr);
         callbackParams.push_back(winrt::TakeJSValue(writer));
         m_callback(callbackParams);
     }
@@ -478,7 +478,7 @@ void DBStorage::DBTask::getAllKeys(sqlite3* db) {
 void DBStorage::DBTask::clear(sqlite3* db) {
     if (Exec(db, m_callback, u8"DELETE FROM AsyncLocalStorage")) {
         std::vector<winrt::JSValue> callbackParams;
-        callbackParams.push_back(winrt::JSValueArray());
+        callbackParams.push_back(nullptr);
         m_callback(callbackParams);
     }
 }

--- a/windows/ReactNativeAsyncStorage/RNCAsyncStorage.h
+++ b/windows/ReactNativeAsyncStorage/RNCAsyncStorage.h
@@ -105,28 +105,28 @@ namespace winrt::ReactNativeAsyncStorage::implementation
         }
 
         REACT_METHOD(getAllKeys);
-        void getAllKeys(std::function<void(JSValueArray const& errors, JSValueArray const& keys)>&& callback) noexcept {
+        void getAllKeys(std::function<void(JSValue const& error, JSValueArray const& keys)>&& callback) noexcept {
             dbStorage.AddTask(DBStorage::DBTask::Type::getAllKeys,
                 [callback{ std::move(callback) }](std::vector<JSValue> const& callbackParams) {
                     if (callbackParams.size() > 0) {
-                        auto& errors = callbackParams[0].AsArray();
+                        auto& error = callbackParams[0];
                         if (callbackParams.size() > 1) {
-                            callback(errors, callbackParams[1].AsArray());
+                            callback(error, callbackParams[1].AsArray());
                         }
                         else {
-                            callback(errors, {});
+                            callback(error, {});
                         }
                     }
                 });
         }
 
         REACT_METHOD(clear);
-        void clear(std::function<void(JSValueArray const&)>&& callback) noexcept {
+        void clear(std::function<void(JSValue const&)>&& callback) noexcept {
             dbStorage.AddTask(DBStorage::DBTask::Type::clear,
                 [callback{ std::move(callback) }](std::vector<JSValue> const& callbackParams) {
                     if (callbackParams.size() > 0) {
-                        auto& errors = callbackParams[0].AsArray();
-                        callback(errors);
+                        auto& error = callbackParams[0];
+                        callback(error);
                     }
                 });
         }


### PR DESCRIPTION
Summary:
---------

On Windows `getAllKeys` was reporting the correct results, but also an empty array error. Unlike the multi* methods, these expect a single error, not an array of errors.
The fix is to change the type sent by the windows implementation from an array to a single object. That object is also just a null value, since there are no errors being reported currently by the windows implementation.

Test Plan:
----------

Manually validated with the repo's example app on Windows. Also tested by patching to a react-native-windows app that was already using async storage and failing on `getAllKeys`.

The test app doesn't contain any usage of `getAllKeys`, which is probably why this was missed.