### PR TITLE
Add flow annotation to index & hooks

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,5 +1,6 @@
 /**
  * @format
+ * @flow
  */
 
 import AsyncStorage from './AsyncStorage';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /**
  * @format
+ * @flow
  */
 
 import AsyncStorage from './AsyncStorage';


### PR DESCRIPTION
Summary:
---------
Including `react-native-community/async-storage` in a new project with flow doesn't actually work due to the index file not having the flow annotation. (Blank project with `[declarations] node_modules/**` in the flowconfig, flow version 0.132.0)

This change adds flow annotations. Runtime wise this is only a comment and thus can't break anything other than flow itself (which still works).

![Screen Shot 2020-08-26 at 6 27 14 PM](https://user-images.githubusercontent.com/7523484/91481379-2cd34c80-e859-11ea-8f8c-3c90954a01c1.png)

Test Plan:
----------
`yarn test` still works.
I'm not completely familiar with how the build process works, but my understanding is that the .flow files in lib will be copied over as is. Thus, the output would look like this, and flow typing would now work:
![Screen Shot 2020-08-27 at 11 36 37 AM](https://user-images.githubusercontent.com/7523484/91481706-ae2adf00-e859-11ea-8486-f94edfa22f68.png)

If this looks good, I can also bump the version before merging if you'd like.