### PR TITLE
Improved check for invalid parameters

### DIFF
--- a/src/AsyncStorage.native.js
+++ b/src/AsyncStorage.native.js
@@ -51,7 +51,7 @@ function checkValidInput(usedKey: string, value: any) {
   const isValuePassed = arguments.length > 1;
 
   if (typeof usedKey !== 'string') {
-    console.warn(
+    throw new Error(
       `[AsyncStorage] Using ${typeof usedKey} type for key is not supported. This can lead to unexpected behavior/errors. Use string instead.\nKey passed: ${usedKey}\n`,
     );
   }
@@ -62,7 +62,7 @@ function checkValidInput(usedKey: string, value: any) {
         `[AsyncStorage] Passing null/undefined as value is not supported. If you want to remove value, Use .remove method instead.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
       );
     } else {
-      console.warn(
+      throw new Error(
         `[AsyncStorage] The value for key "${usedKey}" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
       );
     }


### PR DESCRIPTION
Summary:
---------

Printing a warning message from `checkValidInput` doesn't seem to work as intended.

In the following case, when an incorrect key or value is passed, `RCTAsyncStorage.multiSet` native function is called and an error occurs unconditionally. This is an unnecessary call.
```js
setItem: function(...) {
  return new Promise((resolve, reject) => {
    checkValidInput(key, value);
    RCTAsyncStorage.multiSet([[key, value]], function(errors) {
    ...
  }
}
```

I think it's better to throw an error in all cases where parameter check is necessary. This is because the thrown error is displayed in RN's `LogBox` and the logic is not executed after the error.

Test Plan:
----------

None